### PR TITLE
Add initial project setup with Go module and main package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ go.work.sum
 
 # env file
 .env
+
+# idea files
+.idea/

--- a/cmd/gotext-translate/main.go
+++ b/cmd/gotext-translate/main.go
@@ -1,0 +1,1 @@
+package main

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ksysoev/gotext-translator
+
+go 1.24.1


### PR DESCRIPTION
Initialized the Go module with the name `github.com/ksysoev/gotext-translator` and specified Go version 1.24.1. Added a placeholder main package and updated `.gitignore` to exclude `.idea` files. This commit sets up the basic structure for the project.